### PR TITLE
Added github actions for lib and tox

### DIFF
--- a/.github/workflows/build_lib.yaml
+++ b/.github/workflows/build_lib.yaml
@@ -1,0 +1,55 @@
+name: Build lib
+
+on:
+  workflow_call:
+
+jobs:
+  build_lib:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install poetry
+        run: pip install poetry
+
+      - name: Make versions
+        run: |
+          chmod +x ./tools/version.sh
+          ./tools/version.sh "${{ github.sha }}" "none"
+          echo "APP_VERSION=$(cat "./VERSION")" >> $GITHUB_ENV
+          echo "DOCKER_IMAGES=$(cat "./DOCKER_IMAGES")" >> $GITHUB_ENV
+
+      - name: Install dependencies
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry install --no-root --with dev
+
+      - name: Build package
+        run: |
+          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+          poetry build
+
+      - name: Publish to pypi
+        # The version in PyPI must follow the PEP 440 standard.
+        # Semantic versioning is not supported by PyPI.
+        # Therefore, only the release version is published.
+        run: |
+          if [[ ${{ github.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            poetry publish
+          fi
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Create a github release
+        run: gh release create "${{ env.APP_VERSION }}" ./dist/*
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -1,50 +1,11 @@
-name: Test, build and release
+name: Build web
 
 on:
-  push:
-    branches:
-      - '**'
-    tags:
-      - '**'
-    paths-ignore:
-      - 'releases/**'
-  pull_request:
-    branches:
-      - '**'
-  workflow_dispatch:
+  workflow_call:
 
 jobs:
-  test:
+  build_web:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install poetry
-        run: pip install poetry
-
-      - name: Install dependencies
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry install --no-root --with dev,test
-
-      - name: Run style checks
-        run: |
-          poetry run mypy .
-          poetry run isort . --check --diff
-          poetry run flake8 .
-          poetry run black . --check --diff
-
-      - name: Run tests
-        run: poetry run pytest
-
-  build:
-    runs-on: ubuntu-latest
-    needs: [test]
     permissions:
       contents: write
     steps:
@@ -108,7 +69,7 @@ jobs:
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-      - name: Create github release
+      - name: Create a github release
         run: gh release create "${{ env.APP_VERSION }}" ./release/*
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -1,0 +1,52 @@
+name: Test and build
+
+on:
+  push:
+    branches:
+      - '**'
+    tags:
+      - '**'
+    paths-ignore:
+      - 'releases/**'
+  pull_request:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install poetry
+        run: pip install poetry
+
+      - name: Install dependencies
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry install --no-root --with dev,test
+
+      - name: Run style checks
+        run: |
+          poetry run mypy .
+          poetry run isort . --check --diff
+          poetry run flake8 .
+          poetry run black . --check --diff
+
+      - name: Run tests
+        run: poetry run pytest
+
+  build:
+    needs: [test]
+    secrets: inherit
+    # Replace build_web.yaml to build_lib.yaml for lib workflow
+    uses: ./.github/workflows/build_web.yaml

--- a/README.md
+++ b/README.md
@@ -1,15 +1,9 @@
 # template-python
-Web service template in Python for reuse.
+Python service template for reuse.
 
 ## Installation
-1. If you don't have `Poetry` installed run:
-
-```bash
-pip install poetry
-```
-
 <details>
-  <summary>Install Python 3.12 if it is not available in your package manager</summary>
+<summary>Install Python 3.12 if it is not available in your package manager</summary>
 
 These instructions are for Ubuntu 22.04. If you're on a different distribution,
 or - God forbid! - Windows, you should adjust these accordingly.
@@ -20,19 +14,15 @@ Also, these instructions are about using Poetry with Pyenv-managed (non-system) 
 Before we install pyenv, we need to update our package lists for upgrades and new package installations. We also need to install dependencies for pyenv. 
 
 Open your terminal and type:
-
 ```bash
 sudo apt-get update
 sudo apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev \
 libreadline-dev libsqlite3-dev wget curl llvm libncursesw5-dev xz-utils \
 tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-
 ```
-
 
 ### Step 2: Install Pyenv
 We will clone pyenv from the official GitHub repository and add it to our system path.
-
 ```bash
 git clone https://github.com/pyenv/pyenv.git ~/.pyenv
 echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
@@ -41,17 +31,14 @@ echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 exec "$SHELL"
 ```
 
-
 ### Step 3: Install Python 3.12
-Now that pyenv is installed, we can install different Python versions. To install Python 3.12, use the following command.
-
+Now that pyenv is installed, we can install different Python versions. To install Python 3.12, use the following command:
 ```bash
 pyenv install 3.12
 ```
 
 ### Step 4: Connect Poetry to it
 Do this in the template dir. Pycharm will automatically connect to it later
-
 ```bash
 poetry env use ~/.pyenv/versions/3.12.1/bin/python
 ```
@@ -61,105 +48,124 @@ Finally, verify that Poetry indeed is connected to the proper version:
 ```bash
 poetry enf info
 ```
-  
-</details>
+</details>  
+
+1. If you don't have `Poetry` installed run:
+```bash
+pip install poetry
+```
 
 2. Install dependencies:
-
 ```bash
 poetry config virtualenvs.in-project true
 poetry install --no-root --with dev,test
 ```
 
 3. Install `pre-commit` hooks:
-
 ```bash
 poetry run pre-commit install
 ```
 
 4. Launch the project:
-
 ```bash
 poetry run uvicorn app.main:app [--reload]
 ```
-
 or do it in two steps:
 ```bash
 poetry shell
 uvicorn app.main:app
-
 ```
 
-1. Running tests:
-
+5. Running tests:
 ```bash
 poetry run pytest
 ```
 
-6. Building package:
-
+You can test the application for multiple versions of Python. To do this, you need to install the required Python versions on your operating system, specify these versions in the tox.ini file, and then run the tests:
 ```bash
-poetry build
+poetry run tox
 ```
 
-## Docker
-The docker image is automatically built in GitHub Actions after pushing code/tag/pr.
-
-You can build a docker image and create a container manually:
-
+## Package
+To generate and publish a package on pypi.org, execute the following commands:
 ```bash
-docker build . -t <image-name>:<image-tag>
-docker run <image-name>:<image-tag>
+poetry config pypi-token.pypi <pypi_token>
+poetry build
+poetry publish
+```
+
+pypi_token - API token for authentication on PyPI. https://pypi.org/help/#apitoken
+
+## Docker
+Build a docker image and run a container:
+```bash
+docker build . -t <image_name>:<image_tag>
+docker run <image_name>:<image_tag>
+```
+
+Upload the Docker image to the repository:
+```bash
+docker login -u <username>
+docker push <image_name>:<image_tag>
 ```
 
 https://docs.docker.com/
 
-## Release
-The release is automatically built in GitHub Actions and saved to branch gh-pages after pushing code/tag/pr.
-
-Create the branch gh-pages and use it as a GitHub page https://pages.github.com/.  
-The releases will be available at `https://github.com/<workspace>/<project>/releases/download/<app>-<version>/<app>-<version>.tgz`.  
-The index will be available at `https://<workspace>.github.io/<project>/index.yaml`.  
-You can use URL `https://<workspace>.github.io/<project>/` on https://artifacthub.io/.
-
-To create a release, add a tag in GIT with the format a.a.a, where 'a' is an integer.
-The release version for branches, pull requests, and other tags will be generated based on the last tag of the form a.a.a.
-
-The Helm chart version, and Docker images versions will be automatically generated from this version in GitHub Actions.
-
-You can build release manually:
-
+## Helm chart
+Authenticate your Helm client in the container registry:
 ```bash
-helm package charts/<chart-name>
+helm registry login <repo_url> -u <username>
 ```
 
-## OpenAPI schema
-The OpenAPI schema will be generated automatically and saved in the release artifacts `https://github.com/<workspace>/<project>/releases/`.
-
-## Deploy
-The release is automatically deployed to Kubernetes cluster in GitHub Actions.
-
-You can deploy it manually:
-
+Create a Helm chart:
 ```bash
-helm repo add <repo-name> https://<workspace>.github.io/<project>/
-helm repo update <repo-name>
-helm upgrade --install <release-name> <repo-name>/<chart-name>
+helm package charts/<chart_name>
+```
+
+Push the Helm chart to container registry:
+```bash
+helm push <helm_chart_package> <repo_url>
+```
+
+Deploy the Helm chart:
+```bash
+helm repo add <repo_name> <repo_url>
+helm repo update <repo_name>
+helm upgrade --install <release_name> <repo_name>/<chart_name>
 ```
 
 https://helm.sh/ru/docs/
 
-## Classy-FastAPI
-Classy-FastAPI allows you to easily do dependency injection of 
-object instances that should persist between FastAPI routes invocations,
-e.g. database connections.
-More on that (with examples) at [Classy-FastAPI GitLab page](https://gitlab.com/companionlabs-opensource/classy-fastapi
-).
+## OpenaAPI schema
+To manually generate the OpenAPI schema, execute the command:
+```bash
+poetry run python ./tools/extract_openapi.py app.main:app --app-dir . --out openapi.yaml --app_version <version>
+```
+
+## Release
+To create a release, add a tag in GIT with the format a.a.a, where 'a' is an integer.
+The release version for branches, pull requests, and other tags will be generated based on the last tag of the form a.a.a.
 
 ## GitHub Actions
-GitHub Actions run tests, build and push a Docker image, creat and push a Helm chart release, deploy the project to Kubernetes cluster.
+GitHub Actions triggers testing, builds, and application publishing for each release.  
+https://docs.github.com/en/actions  
 
-Setup secrets at `https://github.com/<workspace>/<project>/settings/secrets/actions`:
+You can set up automatic testing in GitHub Actions for different versions of Python. To do this, you need to specify the set of versions in the .github/workflows/test_and_build.yaml file. For example:
+```yaml
+strategy:
+  matrix:
+    python-version: ["3.10", "3.11", "3.12"]
+```
+
+The process of building and publishing differs for web services and libraries.
+
+### Web service
+The default build and publish process is configured for a web application (.github\workflows\build_web.yaml).
+During this process, a Docker image is built, a Helm chart is created, an openapi.yaml is generated, and the web service is deployed to a Kubernetes cluster.
+
+**Initial setup**  
+Create the branch gh-pages and use it as a GitHub page https://pages.github.com/.  
+Set up secrets at `https://github.com/<workspace>/<project>/settings/secrets/actions`:
 1. DOCKER_IMAGE_NAME - The name of the Docker image for uploading to the repository.
 2. DOCKER_USERNAME - The username for the Docker repository on https://hub.docker.com/.
 3. DOCKER_PASSWORD - The password for the Docker repository.
@@ -171,13 +177,42 @@ Setup secrets at `https://github.com/<workspace>/<project>/settings/secrets/acti
 9. EKS_CLUSTER_NAMESPACE - Amazon EKS Kubernetes cluster namespace.
 10. HELM_REPO_URL - `https://<workspace>.github.io/<project>/`
 
-https://docs.github.com/en/actions
+**After execution**  
+The OpenAPI schema and the Helm chart will be available at `https://github.com/<workspace>/<project>/releases/`.  
+The index.yaml file containing the list of Helm charts will be available at `https://<workspace>.github.io/<project>/index.yaml`. You can use URL `https://<workspace>.github.io/<project>/` on https://artifacthub.io/.
 
-You can run your GitHub Actions locally using https://github.com/nektos/act.  
+### Library
+To change the build process for the library, you need to replace the nested workflow ./.github/workflows/build_web.yaml to ./.github/workflows/build_lib.yaml in .github\workflows\test_and_build.yaml:
+```yaml
+build:
+  needs: [test]
+  secrets: inherit
+  uses: ./.github/workflows/build_lib.yaml
+```
+
+After that, during the build process, the package will be built and published on pypi.org.  
+Uploading the package to pypi.org only occurs when a.a.a release is created.
+
+**Initial setup**  
+Set up a secret token for PyPI at `https://github.com/<workspace>/<project>/settings/secrets/actions`.
+https://pypi.org/help/#apitoken
+
+**After execution**  
+A package will be available at `https://github.com/<workspace>/<project>/releases/` and pypi.org. 
+
+## Act
+You can run your GitHub Actions locally using https://github.com/nektos/act. 
+
 Usage example:
 ```bash
 act push -j deploy --secret-file my.secrets
 ```
+
+## Classy-FastAPI
+Classy-FastAPI allows you to easily do dependency injection of 
+object instances that should persist between FastAPI routes invocations,
+e.g. database connections.
+More on that (with examples) at [Classy-FastAPI GitLab page](https://gitlab.com/companionlabs-opensource/classy-fastapi).
 
 # Collaboration guidelines
 HIRO uses and requires from its partners [GitFlow with Forks](https://hirodevops.notion.site/GitFlow-with-Forks-3b737784e4fc40eaa007f04aed49bb2e?pvs=4)

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,18 +13,20 @@ files = [
 
 [[package]]
 name = "anyio"
-version = "4.2.0"
+version = "4.3.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "anyio-4.2.0-py3-none-any.whl", hash = "sha256:745843b39e829e108e518c489b31dc757de7d2131d53fac32bd8df268227bfee"},
-    {file = "anyio-4.2.0.tar.gz", hash = "sha256:e1875bb4b4e2de1669f4bc7869b6d3f54231cdced71605e6e64c9be77e3be50f"},
+    {file = "anyio-4.3.0-py3-none-any.whl", hash = "sha256:048e05d0f6caeed70d731f3db756d35dcc1f35747c8c403364a8332c630441b8"},
+    {file = "anyio-4.3.0.tar.gz", hash = "sha256:f75253795a87df48568485fd18cdd2a3fa5c4f7c5be8e5e36637733fce06fed6"},
 ]
 
 [package.dependencies]
+exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
+typing-extensions = {version = ">=4.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 doc = ["Sphinx (>=7)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
@@ -68,12 +70,25 @@ mypy-extensions = ">=0.4.3"
 packaging = ">=22.0"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "cachetools"
+version = "5.3.2"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "cachetools-5.3.2-py3-none-any.whl", hash = "sha256:861f35a13a451f94e301ce2bec7cac63e881232ccce7ed67fab9b5df4d3beaa1"},
+    {file = "cachetools-5.3.2.tar.gz", hash = "sha256:086ee420196f7b2ab9ca2db2520aca326318b68fe5ba8bc4d49cca91add450f2"},
+]
 
 [[package]]
 name = "certifi"
@@ -95,6 +110,17 @@ python-versions = ">=3.8"
 files = [
     {file = "cfgv-3.4.0-py2.py3-none-any.whl", hash = "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9"},
     {file = "cfgv-3.4.0.tar.gz", hash = "sha256:e52591d4c5f5dead8e0f673fb16db7949d2cfb3f7da4582893288f0ded8fe560"},
+]
+
+[[package]]
+name = "chardet"
+version = "5.2.0"
+description = "Universal encoding detector for Python 3"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
+    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
 ]
 
 [[package]]
@@ -147,6 +173,20 @@ files = [
     {file = "distlib-0.3.8-py2.py3-none-any.whl", hash = "sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784"},
     {file = "distlib-0.3.8.tar.gz", hash = "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"},
 ]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.2.0"
+description = "Backport of PEP 654 (exception groups)"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "exceptiongroup-1.2.0-py3-none-any.whl", hash = "sha256:4bfd3996ac73b41e9b9628b04e079f193850720ea5945fc96a08633c66912f14"},
+    {file = "exceptiongroup-1.2.0.tar.gz", hash = "sha256:91f5c769735f051a4290d52edd0858999b57e5876e9f85937691bd4c9fa3ed68"},
+]
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "fastapi"
@@ -212,13 +252,13 @@ files = [
 
 [[package]]
 name = "httpcore"
-version = "1.0.2"
+version = "1.0.4"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpcore-1.0.2-py3-none-any.whl", hash = "sha256:096cc05bca73b8e459a1fc3dcf585148f63e534eae4339559c9b8a8d6399acc7"},
-    {file = "httpcore-1.0.2.tar.gz", hash = "sha256:9fc092e4799b26174648e54b74ed5f683132a464e95643b226e00c2ed2fa6535"},
+    {file = "httpcore-1.0.4-py3-none-any.whl", hash = "sha256:ac418c1db41bade2ad53ae2f3834a3a0f5ae76b56cf5aa497d2d033384fc7d73"},
+    {file = "httpcore-1.0.4.tar.gz", hash = "sha256:cb2839ccfcba0d2d3c1131d3c3e26dfc327326fbe7a5dc0dbfe9f6c9151bb022"},
 ]
 
 [package.dependencies]
@@ -229,7 +269,7 @@ h11 = ">=0.13,<0.15"
 asyncio = ["anyio (>=4.0,<5.0)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
-trio = ["trio (>=0.22.0,<0.23.0)"]
+trio = ["trio (>=0.22.0,<0.25.0)"]
 
 [[package]]
 name = "httpx"
@@ -257,13 +297,13 @@ socks = ["socksio (==1.*)"]
 
 [[package]]
 name = "identify"
-version = "2.5.33"
+version = "2.5.35"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "identify-2.5.33-py2.py3-none-any.whl", hash = "sha256:d40ce5fcd762817627670da8a7d8d8e65f24342d14539c59488dc603bf662e34"},
-    {file = "identify-2.5.33.tar.gz", hash = "sha256:161558f9fe4559e1557e1bff323e8631f6a0e4837f7497767c1782832f16b62d"},
+    {file = "identify-2.5.35-py2.py3-none-any.whl", hash = "sha256:c4de0081837b211594f8e877a6b4fad7ca32bbfc1a9307fdd61c28bfe923f13e"},
+    {file = "identify-2.5.35.tar.gz", hash = "sha256:10a7ca245cfcd756a554a7288159f72ff105ad233c7c4b9c6f0f4d108f5f6791"},
 ]
 
 [package.extras]
@@ -357,6 +397,7 @@ files = [
 
 [package.dependencies]
 mypy-extensions = ">=1.0.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
 typing-extensions = ">=4.1.0"
 
 [package.extras]
@@ -444,13 +485,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pre-commit"
-version = "3.6.0"
+version = "3.6.2"
 description = "A framework for managing and maintaining multi-language pre-commit hooks."
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "pre_commit-3.6.0-py2.py3-none-any.whl", hash = "sha256:c255039ef399049a5544b6ce13d135caba8f2c28c3b4033277a788f434308376"},
-    {file = "pre_commit-3.6.0.tar.gz", hash = "sha256:d30bad9abf165f7785c15a21a1f46da7d0677cb00ee7ff4c579fd38922efe15d"},
+    {file = "pre_commit-3.6.2-py2.py3-none-any.whl", hash = "sha256:ba637c2d7a670c10daedc059f5c49b5bd0aadbccfcd7ec15592cf9665117532c"},
+    {file = "pre_commit-3.6.2.tar.gz", hash = "sha256:c3ef34f463045c88658c5b99f38c1e297abdcc0ff13f98d3370055fbbfabc67e"},
 ]
 
 [package.dependencies]
@@ -593,6 +634,25 @@ files = [
 ]
 
 [[package]]
+name = "pyproject-api"
+version = "1.6.1"
+description = "API to interact with the python pyproject.toml based projects"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyproject_api-1.6.1-py3-none-any.whl", hash = "sha256:4c0116d60476b0786c88692cf4e325a9814965e2469c5998b830bba16b183675"},
+    {file = "pyproject_api-1.6.1.tar.gz", hash = "sha256:1817dc018adc0d1ff9ca1ed8c60e1623d5aaca40814b953af14a9cf9a5cae538"},
+]
+
+[package.dependencies]
+packaging = ">=23.1"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+docs = ["furo (>=2023.8.19)", "sphinx (<7.2)", "sphinx-autodoc-typehints (>=1.24)"]
+testing = ["covdefaults (>=2.3)", "pytest (>=7.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.11.1)", "setuptools (>=68.1.2)", "wheel (>=0.41.2)"]
+
+[[package]]
 name = "pytest"
 version = "7.4.4"
 description = "pytest: simple powerful testing with Python"
@@ -605,9 +665,11 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
+tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -691,18 +753,18 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "69.0.3"
+version = "69.1.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "setuptools-69.0.3-py3-none-any.whl", hash = "sha256:385eb4edd9c9d5c17540511303e39a147ce2fc04bc55289c322b9e5904fe2c05"},
-    {file = "setuptools-69.0.3.tar.gz", hash = "sha256:be1af57fc409f93647f2e8e4573a142ed38724b8cdd389706a867bb4efcf1e78"},
+    {file = "setuptools-69.1.0-py3-none-any.whl", hash = "sha256:c054629b81b946d63a9c6e732bc8b2513a7c3ea645f11d0139a2191d735c60c6"},
+    {file = "setuptools-69.1.0.tar.gz", hash = "sha256:850894c4195f09c4ed30dba56213bf7c3f21d86ed6bdaafb5df5972593bfc401"},
 ]
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (>=1,<2)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
-testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.develop (>=7.21)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-home (>=0.5)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff (>=0.2.1)", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
 testing-integration = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "packaging (>=23.1)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
@@ -732,6 +794,44 @@ anyio = ">=3.4.0,<5"
 
 [package.extras]
 full = ["httpx (>=0.22.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.7)", "pyyaml"]
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
+name = "tox"
+version = "4.13.0"
+description = "tox is a generic virtualenv management and test command line tool"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tox-4.13.0-py3-none-any.whl", hash = "sha256:1143c7e2489c68026a55d3d4ae84c02c449f073b28e62f80e3e440a3b72a4afa"},
+    {file = "tox-4.13.0.tar.gz", hash = "sha256:dd789a554c16c4b532924ba393c92fc8991323c4b3d466712bfecc8c9b9f24f7"},
+]
+
+[package.dependencies]
+cachetools = ">=5.3.2"
+chardet = ">=5.2"
+colorama = ">=0.4.6"
+filelock = ">=3.13.1"
+packaging = ">=23.2"
+platformdirs = ">=4.1"
+pluggy = ">=1.3"
+pyproject-api = ">=1.6.1"
+tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
+virtualenv = ">=20.25"
+
+[package.extras]
+docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-argparse-cli (>=1.11.1)", "sphinx-autodoc-typehints (>=1.25.2)", "sphinx-copybutton (>=0.5.2)", "sphinx-inline-tabs (>=2023.4.21)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.11)"]
+testing = ["build[virtualenv] (>=1.0.3)", "covdefaults (>=2.3)", "detect-test-pollution (>=1.2)", "devpi-process (>=1)", "diff-cover (>=8.0.2)", "distlib (>=0.3.8)", "flaky (>=3.7)", "hatch-vcs (>=0.4)", "hatchling (>=1.21)", "psutil (>=5.9.7)", "pytest (>=7.4.4)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-xdist (>=3.5)", "re-assert (>=1.1)", "time-machine (>=2.13)", "wheel (>=0.42)"]
 
 [[package]]
 name = "types-pyyaml"
@@ -769,19 +869,20 @@ files = [
 [package.dependencies]
 click = ">=7.0"
 h11 = ">=0.8"
+typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 standard = ["colorama (>=0.4)", "httptools (>=0.5.0)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.14.0,!=0.15.0,!=0.15.1)", "watchfiles (>=0.13)", "websockets (>=10.4)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.25.0"
+version = "20.25.1"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.25.0-py3-none-any.whl", hash = "sha256:4238949c5ffe6876362d9c0180fc6c3a824a7b12b80604eeb8085f2ed7460de3"},
-    {file = "virtualenv-20.25.0.tar.gz", hash = "sha256:bf51c0d9c7dd63ea8e44086fa1e4fb1093a31e963b86959257378aef020e1f1b"},
+    {file = "virtualenv-20.25.1-py3-none-any.whl", hash = "sha256:961c026ac520bac5f69acb8ea063e8a4f071bcc9457b9c1f28f6b085c511583a"},
+    {file = "virtualenv-20.25.1.tar.gz", hash = "sha256:e08e13ecdca7a0bd53798f356d5831434afa5b07b93f0abdf0797b7a06ffe197"},
 ]
 
 [package.dependencies]
@@ -795,5 +896,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.12"
-content-hash = "b11d4235a4b6f0449c706ae5ce40076850bd998e92d0e6576824d50af1a8f8d0"
+python-versions = "^3.10"
+content-hash = "7ff53fd4e9cf8584ce81be09adfa7380df8c4f6e8d8d49e91676304a6872609e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ homepage = "https://github.com/HIRO-MicroDataCenters-BV/python-service-template"
 packages = [{include = "*", from="app"}]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.10"
 fastapi = "^0.109"
 uvicorn = "^0.26"
 classy-fastapi = "^0.6.1"
@@ -33,10 +33,10 @@ types-pyyaml = "^6.0.12.12"
 pytest = "^7.4"
 pytest-mock = "^3.12.0"
 httpx = "^0.26"
+tox = "^4.13.0"
 
 [tool.isort]
 # https://github.com/timothycrosley/isort/
-py_version = "312"
 line_length = 88
 
 known_typing = ["typing", "types", "typing_extensions", "mypy", "mypy_extensions"]
@@ -49,13 +49,11 @@ color_output = true
 
 [tool.black]
 # https://github.com/psf/black
-target-version = ["py312"]
 line-length = 88
 color = true
 
 [tool.mypy]
 # https://mypy.readthedocs.io/en/latest/config_file.html#using-a-pyproject-toml-file
-python_version = '3.12'
 pretty = true
 show_traceback = true
 color_output = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+isolated_build = True
+envlist = py3.10, py3.11, py3.12
+
+[testenv]
+allowlist_externals = poetry
+commands_pre =
+    poetry install --no-root --sync --with test
+commands =
+    poetry run pytest


### PR DESCRIPTION
I've combined the web service and library into one template to simplify maintenance. Switching between them only requires minor configuration changes detailed in the readme.

The workflow has two parts, one for the web service and one for the library, with the default set to the web service.

I've added tox for testing on various Python versions, and also enabled testing on different Python versions in GitHub Actions, all explained in the readme.