### PR TITLE
Move permissions from nested workflow to main

### DIFF
--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -6,8 +6,6 @@ on:
 jobs:
   build_web:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test_and_build.yaml
+++ b/.github/workflows/test_and_build.yaml
@@ -47,6 +47,8 @@ jobs:
 
   build:
     needs: [test]
+    permissions:
+      contents: write
     secrets: inherit
     # Replace build_web.yaml to build_lib.yaml for lib workflow
     uses: ./.github/workflows/build_web.yaml


### PR DESCRIPTION
An error occurred when publishing a GitHub page if the permissions were set in a nested workflow. It worked on my fork. Maybe because the fork is private.