### PR TITLE
Fixed a bug with incorrect calculation of offset in version

### DIFF
--- a/.github/workflows/build_lib.yaml
+++ b/.github/workflows/build_lib.yaml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Python
         uses: actions/setup-python@v5

--- a/.github/workflows/build_web.yaml
+++ b/.github/workflows/build_web.yaml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
The offset from the release version was calculated incorrectly because not the entire commit history was retrieved in the workflow.